### PR TITLE
avoid circular import error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,5 @@ repos:
     rev: 7.1.0
     hooks:
       - id: flake8
-        args: ["--max-line-length=120", "--ignore=F401, W503"]
+        args: ["--max-line-length=120", "--ignore=F401, W503, E402"]
         name: Check PEP8

--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,24 @@
 
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 rootdir = Path(__file__).parent
 long_description = (rootdir / "README.md").read_text()
 
+package_name = "ib_interface"
+
 setup(
-    name="ib_interface",
-    version="0.0.3",
-    description="A Python Framework for Interactive Brokers TWS API",
+    name=package_name,
+    version="0.0.4",
+    package_dir={"": "src"},
+    packages=find_packages(where="src", include=[package_name, f"{package_name}.*"]),
+    include_package_data=True,
+    setup_requires=["wheel"],
+    description="",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author="Justin Goheen",
-    url="https://github.com/jxtngx/ib-interface",
+    author="",
     license="Apache 2.0",
     author_email="",
     zip_safe=False,

--- a/src/ib_interface/__init__.py
+++ b/src/ib_interface/__init__.py
@@ -17,8 +17,6 @@
 import dataclasses
 import sys
 
-import ib_interface.eventkit as eventkit  # noqa: F401
-import ib_interface.nest_asyncio as nest_asyncio  # noqa: F401
 from ib_interface.api import util
 from ib_interface.api.client import Client
 from ib_interface.api.contract import (
@@ -116,9 +114,9 @@ from ib_interface.api.order import (
     VolumeCondition,
 )
 from ib_interface.api.ticker import Ticker
-from ib_interface.api.version import __version__, __version_info__
 from ib_interface.api.wrapper import RequestError, Wrapper
-from ib_interface.eventkit import Event
+from ib_interface.eventkit.event import Event
+from ib_interface.version import __version__, __version_info__
 
 __all__ = [
     "Event",

--- a/src/ib_interface/api/connection.py
+++ b/src/ib_interface/api/connection.py
@@ -16,8 +16,7 @@
 
 import asyncio
 
-from api.util import getLoop
-
+from ib_interface.api.util import getLoop
 from ib_interface.eventkit import Event
 
 

--- a/src/ib_interface/api/contract.py
+++ b/src/ib_interface/api/contract.py
@@ -18,7 +18,7 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import List, NamedTuple, Optional
 
-import api.util as util
+import ib_interface.api.util as util
 
 
 @dataclass

--- a/src/ib_interface/api/flexreport.py
+++ b/src/ib_interface/api/flexreport.py
@@ -20,8 +20,8 @@ import xml.etree.ElementTree as et
 from contextlib import suppress
 from urllib.request import urlopen
 
-from api import util
-from api.objects import DynamicObject
+from ib_interface.api import util
+from ib_interface.api.objects import DynamicObject
 
 _logger = logging.getLogger("ib_insync.flexreport")
 

--- a/src/ib_interface/api/ib.py
+++ b/src/ib_interface/api/ib.py
@@ -21,10 +21,10 @@ import logging
 import time
 from typing import Awaitable, Dict, Iterator, List, Optional, Union
 
-import api.util as util
-from api.client import Client
-from api.contract import Contract, ContractDescription, ContractDetails
-from api.objects import (
+import ib_interface.api.util as util
+from ib_interface.api.client import Client
+from ib_interface.api.contract import Contract, ContractDescription, ContractDetails
+from ib_interface.api.objects import (
     AccountValue,
     BarDataList,
     DepthMktDataDescription,
@@ -53,10 +53,9 @@ from api.objects import (
     TradeLogEntry,
     WshEventData,
 )
-from api.order import BracketOrder, LimitOrder, Order, OrderState, OrderStatus, StopOrder, Trade
-from api.ticker import Ticker
-from api.wrapper import Wrapper
-
+from ib_interface.api.order import BracketOrder, LimitOrder, Order, OrderState, OrderStatus, StopOrder, Trade
+from ib_interface.api.ticker import Ticker
+from ib_interface.api.wrapper import Wrapper
 from ib_interface.eventkit import Event
 
 

--- a/src/ib_interface/api/ibcontroller.py
+++ b/src/ib_interface/api/ibcontroller.py
@@ -21,10 +21,9 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import ClassVar
 
-import api.util as util
-from api.contract import Contract, Forex
-from api.ib import IB
-
+import ib_interface.api.util as util
+from ib_interface.api.contract import Contract, Forex
+from ib_interface.api.ib import IB
 from ib_interface.eventkit import Event
 
 

--- a/src/ib_interface/api/ticker.py
+++ b/src/ib_interface/api/ticker.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import ClassVar, List, Optional, Union
 
-from api.contract import Contract
-from api.objects import (
+from ib_interface.api.contract import Contract
+from ib_interface.api.objects import (
     Dividends,
     DOMLevel,
     FundamentalRatios,
@@ -30,8 +30,7 @@ from api.objects import (
     TickByTickMidPoint,
     TickData,
 )
-from api.util import dataclassRepr, isNan
-
+from ib_interface.api.util import dataclassRepr, isNan
 from ib_interface.eventkit import Event, Op
 
 nan = float("nan")

--- a/src/ib_interface/api/util.py
+++ b/src/ib_interface/api/util.py
@@ -24,7 +24,7 @@ import time
 from dataclasses import fields, is_dataclass
 from typing import AsyncIterator, Awaitable, Callable, Iterator, List, Optional, Union
 
-from ib_interface import eventkit as ev
+from ib_interface.eventkit.event import Event
 
 try:
     from zoneinfo import ZoneInfo
@@ -32,7 +32,7 @@ except ImportError:
     from backports.zoneinfo import ZoneInfo  # type: ignore
 
 
-globalErrorEvent = ev.Event()
+globalErrorEvent = Event()
 """
 Event to emit global exceptions.
 """

--- a/src/ib_interface/api/wrapper.py
+++ b/src/ib_interface/api/wrapper.py
@@ -21,8 +21,8 @@ from contextlib import suppress
 from datetime import datetime, timezone
 from typing import Any, cast, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
-from api.contract import Contract, ContractDescription, ContractDetails, DeltaNeutralContract, ScanData
-from api.objects import (
+from ib_interface.api.contract import Contract, ContractDescription, ContractDetails, DeltaNeutralContract, ScanData
+from ib_interface.api.objects import (
     AccountValue,
     BarData,
     BarDataList,
@@ -64,9 +64,9 @@ from api.objects import (
     TickData,
     TradeLogEntry,
 )
-from api.order import Order, OrderState, OrderStatus, Trade
-from api.ticker import Ticker
-from api.util import (
+from ib_interface.api.order import Order, OrderState, OrderStatus, Trade
+from ib_interface.api.ticker import Ticker
+from ib_interface.api.util import (
     dataclassAsDict,
     dataclassUpdate,
     getLoop,
@@ -78,7 +78,7 @@ from api.util import (
 )
 
 if TYPE_CHECKING:
-    from api.ib import IB
+    from ib_interface.api.ib import IB
 
 
 OrderKeyType = Union[int, Tuple[int, int]]

--- a/src/ib_interface/eventkit/event.py
+++ b/src/ib_interface/eventkit/event.py
@@ -19,38 +19,6 @@ import weakref
 from typing import Any as AnyType
 from typing import AsyncIterable, Awaitable, Iterable, List, Optional, Tuple, Union
 
-from ib_interface.eventkit.ops.aggregate import All, Any, Count, Deque, Ema
-from ib_interface.eventkit.ops.aggregate import List as ListOp
-from ib_interface.eventkit.ops.aggregate import Max, Mean, Min, Pairwise, Product, Reduce, Sum
-from ib_interface.eventkit.ops.array import Array
-from ib_interface.eventkit.ops.combine import AddableJoinOp, Chain, Concat, Fork, Merge, Switch, Zip, Ziplatest
-from ib_interface.eventkit.ops.create import Aiterate, Marble, Range, Repeat, Sequence, Timer, Timerange, Wait
-from ib_interface.eventkit.ops.misc import EndOnError, Errors
-from ib_interface.eventkit.ops.op import Op
-from ib_interface.eventkit.ops.select import Changes, DropWhile, Filter, Last, Skip, Take, TakeUntil, TakeWhile, Unique
-from ib_interface.eventkit.ops.timing import Debounce, Delay, Sample, Throttle, Timeout
-from ib_interface.eventkit.ops.transform import (
-    Chainmap,
-    Chunk,
-    ChunkWith,
-    Concatmap,
-    Constant,
-    Copy,
-    Deepcopy,
-    Emap,
-    Enumerate,
-    Iterate,
-    Map,
-    Mergemap,
-    Pack,
-    Partial,
-    PartialRight,
-    Pluck,
-    Previous,
-    Star,
-    Switchmap,
-    Timestamp,
-)
 from ib_interface.eventkit.util import get_event_loop, main_event_loop, NO_VALUE
 
 
@@ -133,7 +101,7 @@ class Event:
 
         The ``+=`` operator can be used as a synonym for this method::
 
-            from ib_interface import eventkit as ev
+            import eventkit as ev
 
             def f(a, b):
                 print(a * b)
@@ -276,7 +244,7 @@ class Event:
         Start the asyncio event loop, run this event to completion and
         return all values as a list::
 
-            from ib_interface import eventkit as ev
+            import eventkit as ev
 
             ev.Timer(0.25, count=10).run()
             ->
@@ -299,7 +267,7 @@ class Event:
         """
         Form several events into a pipe::
 
-            from ib_interface import eventkit as ev
+            import eventkit as ev
 
             e1 = ev.Sequence('abcde')
             e2 = ev.Enumerate().map(lambda i, c: (i, i + ord(c)))
@@ -325,7 +293,7 @@ class Event:
         Fork this event into one or more target events.
         Square brackets can be used as a synonym::
 
-            from ib_interface import eventkit as ev
+            import eventkit as ev
 
             ev.Range(2, 5)[ev.Min, ev.Max, ev.Sum].zip()
             ->
@@ -1331,3 +1299,49 @@ class Event:
         End on any error from the source.
         """
         return EndOnError(self)
+
+
+# avoid circular import error
+# noqa: E402
+from ib_interface.eventkit.ops.aggregate import All, Any, Count, Deque, Ema
+from ib_interface.eventkit.ops.aggregate import List as ListOp
+from ib_interface.eventkit.ops.aggregate import Max, Mean, Min, Pairwise, Product, Reduce, Sum
+from ib_interface.eventkit.ops.array import (
+    Array,
+    ArrayAll,
+    ArrayAny,
+    ArrayMax,
+    ArrayMean,
+    ArrayMin,
+    ArrayProd,
+    ArrayStd,
+    ArraySum,
+)
+from ib_interface.eventkit.ops.combine import AddableJoinOp, Chain, Concat, Fork, Merge, Switch, Zip, Ziplatest
+from ib_interface.eventkit.ops.create import Aiterate, Marble, Range, Repeat, Sequence, Timer, Timerange, Wait
+from ib_interface.eventkit.ops.misc import EndOnError, Errors
+from ib_interface.eventkit.ops.op import Op
+from ib_interface.eventkit.ops.select import Changes, DropWhile, Filter, Last, Skip, Take, TakeUntil, TakeWhile, Unique
+from ib_interface.eventkit.ops.timing import Debounce, Delay, Sample, Throttle, Timeout
+from ib_interface.eventkit.ops.transform import (
+    Chainmap,
+    Chunk,
+    ChunkWith,
+    Concatmap,
+    Constant,
+    Copy,
+    Deepcopy,
+    Emap,
+    Enumerate,
+    Iterate,
+    Map,
+    Mergemap,
+    Pack,
+    Partial,
+    PartialRight,
+    Pluck,
+    Previous,
+    Star,
+    Switchmap,
+    Timestamp,
+)

--- a/src/ib_interface/eventkit/ops/array.py
+++ b/src/ib_interface/eventkit/ops/array.py
@@ -16,7 +16,7 @@ from collections import deque
 
 import numpy as np
 
-from ib_interface.eventkit.ops import Op
+from ib_interface.eventkit.ops.op import Op
 from ib_interface.eventkit.util import NO_VALUE
 
 

--- a/src/ib_interface/version.py
+++ b/src/ib_interface/version.py
@@ -14,5 +14,5 @@
 
 """Version info."""
 
-__version_info__ = (0, 9, 86)
+__version_info__ = (0, 0, 3)
 __version__ = ".".join(str(v) for v in __version_info__)


### PR DESCRIPTION
ignore E402 and imports at bottom of page in `ib_interface.eventkit.event`